### PR TITLE
Bundle gobject-introspection

### DIFF
--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -20,6 +20,22 @@ modules:
         url: https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz
         sha256: ca5218fade0204d59947126c38439f432853543b0818d9d728c589dfe7f3a421
 
+  - name: gobject-introspection
+    cleanup-platform:
+      - "*"
+      - "/lib/*/gobject-introspection/giscanner"
+      - "/share/gobject-introspection/giscanner"
+      - "/bin"
+    config-opts:
+      - '--disable-static'
+    ensure-writable:
+      - "/lib/*/gobject-introspection/giscanner/*.pyc"
+      - "/lib/*/gobject-introspection/giscanner/*/*.pyc"
+    sources:
+      - type: archive
+        url: "https://download.gnome.org/sources/gobject-introspection/1.58/gobject-introspection-1.58.3.tar.xz"
+        sha256: "025b632bbd944dcf11fc50d19a0ca086b83baf92b3e34936d008180d28cdc3c8"
+
   - name: vala
     cleanup-platform:
       - "*"


### PR DESCRIPTION
The issue seems to be that gobject-introspection in 3.32
generates gir that valac 0.40 and friends can't handle.
Bundle the same version of gobject-introspection that's in
3.30 to avoid this for now.

Temporary mitigation for #7. Let's not kill flathub first and
we can find a better fix later.