### PR TITLE
Update valac/gee/gi to latest GNOME upstream version

### DIFF
--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -23,40 +23,40 @@ modules:
         sha256: ca5218fade0204d59947126c38439f432853543b0818d9d728c589dfe7f3a421
 
   - name: gobject-introspection
+    buildsystem: meson
     cleanup-platform:
       - "*"
       - "/lib/*/gobject-introspection/giscanner"
       - "/share/gobject-introspection/giscanner"
       - "/bin"
-    config-opts:
-      - '--disable-static'
     ensure-writable:
       - "/lib/*/gobject-introspection/giscanner/*.pyc"
       - "/lib/*/gobject-introspection/giscanner/*/*.pyc"
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/gobject-introspection/1.58/gobject-introspection-1.58.3.tar.xz
-        sha256: 025b632bbd944dcf11fc50d19a0ca086b83baf92b3e34936d008180d28cdc3c8
+        url: https://download.gnome.org/sources/gobject-introspection/1.64/gobject-introspection-1.64.1.tar.xz
+        sha256: 80beae6728c134521926affff9b2e97125749b38d38744dc901f4010ee3e7fa7
 
   - name: vala
+    buildsystem: autotools
     cleanup-platform:
       - "*"
     config-opts:
-      - --enable-vapigen
       - --enable-unversioned
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/vala/0.40/vala-0.40.11.tar.xz
-        sha256: 1fc591258b63cbb0721c784d8a0abedbb178f4205132a7ee3141f32667301576
+        url: https://download.gnome.org/sources/vala/0.48/vala-0.48.5.tar.xz
+        sha256: a3d4c0e0dadd4c64962205d2f448af72d6bd8c67919d984012b8a41b843ec757
 
   - name: libgee
+    buildsystem: autotools
     make-install-args:
       - girdir=/app/share/gir-1.0
       - typelibdir=/app/lib/girepository-1.0
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/libgee/0.20/libgee-0.20.1.tar.xz
-        sha256: bb2802d29a518e8c6d2992884691f06ccfcc25792a5686178575c7111fea4630
+        url: https://download.gnome.org/sources/libgee/0.20/libgee-0.20.3.tar.xz
+        sha256: d0b5edefc88cbca5f1709d19fa62aef490922c6577a14ac4e7b085507911a5de
 
   - name: granite
     buildsystem: meson


### PR DESCRIPTION
The included Vala version is somewhat dated, so this updates the compiler and the libraries it uses. I did not touch any of the elementaryOS stuff.