### PR TITLE
Update from juno-23.08 to circe-24.08

### DIFF
--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -52,8 +52,8 @@ modules:
       - /share/applications
     sources:
       - type: archive
-        url: https://github.com/elementary/granite/archive/5.5.0.tar.gz
-        sha256: 0c376520c7d462fca05213a14970ee1075fea4a78062a33b47529e2647cd5557
+        url: https://github.com/elementary/granite/archive/6.2.0.tar.gz
+        sha256: 067d31445da9808a802fca523630c3e4b84d2d7c78ae547ced017cb7f3b9c6b5
   
   - name: elementary-theme
     buildsystem: meson

--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -68,8 +68,8 @@ modules:
       - -Dpalettes=false
     sources:
       - type: archive
-        url: https://github.com/elementary/icons/archive/5.3.1.tar.gz
-        sha256: 67b349453f8990e399521bb8d96f4caf4c23a27cf22cbc18ddacf0e817c59e12
+        url: https://github.com/elementary/icons/archive/8.0.0.tar.gz
+        sha256: 2b607c52ec85ef9f683eb28739756d0db942fb5f4c214f4f2fbc768fc6377a1d
     modules:
       - name: xcursorgen
         cleanup:

--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -1,8 +1,8 @@
 id: io.elementary.BaseApp
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
-runtime-version: '23.08'
-branch: circe-23.08
+runtime-version: '24.08'
+branch: circe-24.08
 separate-locales: false
 cleanup:
   - /cache
@@ -40,6 +40,9 @@ modules:
     make-install-args:
       - girdir=/app/share/gir-1.0
       - typelibdir=/app/lib/girepository-1.0
+    build-options:
+      # GCC 14 doesn't like this libgee release
+      cflags: -Wno-error=incompatible-pointer-types
     sources:
       - type: archive
         url: https://download.gnome.org/sources/libgee/0.20/libgee-0.20.6.tar.xz

--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -76,5 +76,5 @@ modules:
           - '*'
         sources:
           - type: archive
-            url: https://gitlab.freedesktop.org/xorg/app/xcursorgen/-/archive/xcursorgen-1.0.7/xcursorgen-xcursorgen-1.0.7.tar.gz
-            sha256: 7fb30a052b63e3ed02c9e43bd70fe1bf8189f2f3d702ab43b5b0726a2dbafccd
+            url: https://gitlab.freedesktop.org/xorg/app/xcursorgen/-/archive/xcursorgen-1.0.8/xcursorgen-xcursorgen-1.0.8.tar.gz
+            sha256: 390204bd72ab722e42c8a09f0a6e918a964ad8cefee02148d771c9be11e533e1

--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -2,7 +2,7 @@ id: io.elementary.BaseApp
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
 runtime-version: '23.08'
-branch: juno-23.08
+branch: circe-23.08
 separate-locales: false
 cleanup:
   - /cache

--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -33,8 +33,8 @@ modules:
       - --enable-unversioned
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/vala/0.48/vala-0.48.14.tar.xz
-        sha256: dca57de29f4ce18ee8c6b1e4f1b37ca3843d19dae5c455fceebccc5ae3ffe347
+        url: https://download.gnome.org/sources/vala/0.56/vala-0.56.17.tar.xz
+        sha256: 26100c4e4ef0049c619275f140d97cf565883d00c7543c82bcce5a426934ed6a
 
   - name: libgee
     make-install-args:

--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -45,6 +45,32 @@ modules:
         url: https://download.gnome.org/sources/libgee/0.20/libgee-0.20.6.tar.xz
         sha256: 1bf834f5e10d60cc6124d74ed3c1dd38da646787fbf7872220b8b4068e476d4d
 
+  - name: sassc
+    cleanup:
+      - '*'
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://github.com/sass/sassc/archive/3.6.2.tar.gz
+        sha256: 608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03
+      - type: script
+        dest-filename: autogen.sh
+        commands:
+          - autoreconf -si
+    modules:
+      - name: libsass
+        cleanup:
+          - '*'
+        buildsystem: autotools
+        sources:
+          - type: archive
+            url: https://github.com/sass/libsass/archive/3.6.5.tar.gz
+            sha256: 89d8f2c46ae2b1b826b58ce7dde966a176bac41975b82e84ad46b01a55080582
+          - type: script
+            dest-filename: autogen.sh
+            commands:
+              - autoreconf -si
+
   - name: granite
     buildsystem: meson
     cleanup:
@@ -59,8 +85,8 @@ modules:
     buildsystem: meson
     sources:
       - type: archive
-        url: https://github.com/elementary/stylesheet/archive/5.4.2.tar.gz
-        sha256: 3bc37723daf4ce0b7c9ce4c125ef0055affe8d6654981388ec87d4a23a1ae0ec
+        url: https://github.com/elementary/stylesheet/archive/8.1.0.tar.gz
+        sha256: 9a23f2e7a25993da5d9356e2840c6ce1c9a7c837a024a5a0cc5e3844df6c7901
 
   - name: elementary-icons
     buildsystem: meson

--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -42,8 +42,8 @@ modules:
       - typelibdir=/app/lib/girepository-1.0
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/libgee/0.20/libgee-0.20.3.tar.xz
-        sha256: d0b5edefc88cbca5f1709d19fa62aef490922c6577a14ac4e7b085507911a5de
+        url: https://download.gnome.org/sources/libgee/0.20/libgee-0.20.6.tar.xz
+        sha256: 1bf834f5e10d60cc6124d74ed3c1dd38da646787fbf7872220b8b4068e476d4d
 
   - name: granite
     buildsystem: meson

--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -22,8 +22,8 @@ modules:
       - /share/graphviz
     sources:
       - type: archive
-        url: https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz
-        sha256: ca5218fade0204d59947126c38439f432853543b0818d9d728c589dfe7f3a421
+        url: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/12.1.2/graphviz-12.1.2.tar.gz
+        sha256: f219ef266ffe68ba7d41eec8a716f1dfa1152e1987ff50f3b1dde6aa19f5d7de
 
   - name: vala
     cleanup-platform:

--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -90,6 +90,9 @@ modules:
       - type: archive
         url: https://github.com/elementary/stylesheet/archive/8.1.0.tar.gz
         sha256: 9a23f2e7a25993da5d9356e2840c6ce1c9a7c837a024a5a0cc5e3844df6c7901
+    post-install:
+      # Fallback "elementary", the theme name before stylesheet 6.0.0, to the blueberry variant
+      - ln -s /app/share/themes/io.elementary.stylesheet.blueberry /app/share/themes/elementary
 
   - name: elementary-icons
     buildsystem: meson


### PR DESCRIPTION
Updates for elementary OS 8.

NOTE: This branch is based on `branch/juno-23.08` for now, but I'd like the maintainers of this repository to make a new branch named `branch/circe-24.08` and merge this branch into it.

- Update Freedesktop runtime to 24.08
- Update modules version
- Update the branch name from 6 Juno to 8 Circe
  - FYI the codename of elementary OS 8 will be Circe
  - See also: https://github.com/elementary/os/blob/dcfbeb5229fbbce862c66e05c01ebb97a4faca14/etc/terraform-stable-8.0-azure.conf#L11