### PR TITLE
Cleanup unnecessary metainfo of modules

### DIFF
--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -46,6 +46,7 @@ modules:
     cleanup:
       - /bin
       - /share/applications
+      - /share/metainfo
     sources:
       - type: archive
         url: https://github.com/elementary/granite/archive/6.2.0.tar.gz
@@ -53,6 +54,8 @@ modules:
   
   - name: elementary-theme
     buildsystem: meson
+    cleanup:
+      - /share/metainfo
     sources:
       - type: archive
         url: https://github.com/elementary/stylesheet/archive/8.1.0.tar.gz
@@ -63,6 +66,8 @@ modules:
 
   - name: elementary-icons
     buildsystem: meson
+    cleanup:
+      - /share/metainfo
     config-opts:
       - -Dpalettes=false
     sources:


### PR DESCRIPTION
Used https://github.com/flathub/com.github.gijsgoudzwaard.image-optimizer/pull/10 for testing.

### Before
```
user@fedora:~/work/com.github.gijsgoudzwaard.image-optimizer$ flatpak run --command=sh com.github.gijsgoudzwaard.image-optimizer 
[📦 com.github.gijsgoudzwaard.image-optimizer com.github.gijsgoudzwaard.image-optimizer]$ ls /app/share/metainfo/
com.github.gijsgoudzwaard.image-optimizer.metainfo.xml	granite.appdata.xml  io.elementary.icons.metainfo.xml  io.elementary.stylesheet.appdata.xml
[📦 com.github.gijsgoudzwaard.image-optimizer com.github.gijsgoudzwaard.image-optimizer]$ 
```

### After

```
user@fedora:~/work/com.github.gijsgoudzwaard.image-optimizer$ flatpak run --command=sh com.github.gijsgoudzwaard.image-optimizer 
[📦 com.github.gijsgoudzwaard.image-optimizer com.github.gijsgoudzwaard.image-optimizer]$ ls /app/share/metainfo/
com.github.gijsgoudzwaard.image-optimizer.metainfo.xml
[📦 com.github.gijsgoudzwaard.image-optimizer com.github.gijsgoudzwaard.image-optimizer]$ 
```