### PR TITLE
Update from circe-24.08 to circe-25.08

### DIFF
--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -100,5 +100,5 @@ modules:
       - -Dtests=false
     sources:
       - type: archive
-        url: https://github.com/flatpak/libportal/releases/download/0.9.0/libportal-0.9.0.tar.xz
-        sha256: 113910f06f39387328805397053d20c7acafb7388d8e6cd5e06e05efb9690735
+        url: https://github.com/flatpak/libportal/releases/download/0.9.1/libportal-0.9.1.tar.xz
+        sha256: de801ee349ed3c255a9af3c01b1a401fab5b3fc1c35eb2fd7dfb35d4b8194d7f

--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -66,8 +66,8 @@ modules:
       - /share/metainfo
     sources:
       - type: archive
-        url: https://github.com/elementary/stylesheet/archive/8.2.0.tar.gz
-        sha256: c63a344a312a72adb20af370d5810d0961b7fbf88c67fc5d08b1226bbcba7dc6
+        url: https://github.com/elementary/stylesheet/archive/8.2.1.tar.gz
+        sha256: d0b4f41dc7df37c0eaa6c7daa61d896e4520279b9edfd89e7714ede36794ffc6
     post-install:
       # Fallback "elementary", the theme name before stylesheet 6.0.0, to the blueberry variant
       - ln -s /app/share/themes/io.elementary.stylesheet.blueberry /app/share/themes/elementary

--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -2,7 +2,7 @@ id: io.elementary.BaseApp
 runtime: org.gnome.Platform
 sdk: org.gnome.Sdk
 runtime-version: '47'
-branch: circe-24.08
+branch: circe-25.08
 separate-locales: false
 cleanup:
   - /cache

--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -57,8 +57,8 @@ modules:
       - /share/metainfo
     sources:
       - type: archive
-        url: https://github.com/elementary/granite/archive/refs/tags/7.6.0.tar.gz
-        sha256: 4b4e4f7f86eb3f55116faec42ebd87e04c3e424d82715ecd967ed39540dca5ef
+        url: https://github.com/elementary/granite/archive/refs/tags/7.7.0.tar.gz
+        sha256: e1fe86f95a528fbcc45bbf85b668935dbd2cbf5d128f824d100ff02031ab5441
 
   - name: elementary-theme
     buildsystem: meson

--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -1,7 +1,7 @@
 id: io.elementary.BaseApp
 runtime: org.gnome.Platform
 sdk: org.gnome.Sdk
-runtime-version: '47'
+runtime-version: '49'
 branch: circe-25.08
 separate-locales: false
 cleanup:


### PR DESCRIPTION
Fixes #34

NOTE: This branch is based on `branch/circe-24.08` for now, but I'd like the maintainers of this repository to make a new branch named `branch/circe-25.08` and merge this branch into it.

- Update GNOME runtime from 47 (EOL) to 49
- Update modules version
    - Update libportal to 0.9.1
    - Update stylesheet to 8.2.1
    - Update granite-7 to 7.7.0

## Checklist
- [x] I confirmed this branch builds successfully on my local
- [x] I confirmed an app based on io.elementary.BaseApp//circe-25.08 builds and launches successfully on my local
    - I used pantheon-tweaks/pantheon-tweaks#330 for test
