### PR TITLE
Mark BaseApp version 23.08 as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
     "skip-appstream-check": true,
-    "end-of-life": "This version of the io.elementary.BaseApp is no longer maintained."    
+    "end-of-life": "This version of the io.elementary.BaseApp is no longer maintained."
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "skip-appstream-check": true
+    "skip-appstream-check": true,
+    "end-of-life": "This version of the io.elementary.BaseApp is no longer maintained."    
 }


### PR DESCRIPTION
This version of the io.elementary.BaseApp is no longer maintained.