### PR TITLE
Revert "Mark BaseApp version 24.08 as EOL"

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-    "skip-appstream-check": true,
-    "end-of-life": "This version of the io.elementary.BaseApp is no longer maintained."
+    "skip-appstream-check": true
 }


### PR DESCRIPTION
Reverts flathub/io.elementary.BaseApp#61

Because this seems to affects to all versions of the BaseApp as I observed in https://github.com/flathub/io.elementary.BaseApp/issues/54#issuecomment-4414671155
