### PR TITLE
libgee: Do not purge libgee-0.8.so*

### DIFF
--- a/io.elementary.BaseApp.yml
+++ b/io.elementary.BaseApp.yml
@@ -183,7 +183,6 @@ modules:
           - rm -rfv ${FLATPAK_DEST}/lib/pkgconfig
           - rm -rfv ${FLATPAK_DEST}/share/gir-1.0
           - rm -rfv ${FLATPAK_DEST}/share/vala
-          - rm -rfv ${FLATPAK_DEST}/lib/libgee*
           # TODO: Remove libsass from here in favor of cleanup in the libsass module itself
           - rm -rfv ${FLATPAK_DEST}/lib/libsass*
     build-commands:


### PR DESCRIPTION
We're shipping libgee so that this BaseApp can be used not only with GNOME runtime but also with fd.o one. However, we're purging its shared object when cleanup-BaseApp.sh is executed, resulting an app that bases on this BaseApp and uses fd.o runtime is successfully built but can fail to launch with the following error:

> error while loading shared libraries: libgee-0.8.so.2: cannot open shared object file: No such file or directory

libgee is widely used in many Vala projects, so let's make sure not to purge its shared object.
